### PR TITLE
lower model references to match between dbt and database (spark)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -200,7 +200,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
         yield inspect(self.engine)
 
     def get_table_fqn(self, service_name, schema, table_name) -> str:
-        return f"{service_name}.{schema}.{table_name}".lower()
+        return f"{service_name}.{schema}.{table_name}"
 
     def next_record(self) -> Iterable[Entity]:
         inspectors = self.get_databases()
@@ -433,7 +433,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
                     table = table.replace(".", "_DOT_")
                     table_fqn = self.get_table_fqn(
                         self.config.service_name, database, table
-                    )
+                    ).lower()
                     upstream_nodes.append(table_fqn)
                 except Exception as err:  # pylint: disable=broad-except
                     logger.error(

--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -443,7 +443,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
         return upstream_nodes
 
     def _get_data_model(self, schema, table_name):
-        table_fqn = f"{schema}.{table_name}"
+        table_fqn = f"{schema}.{table_name}".lower()
         if table_fqn in self.data_models:
             model = self.data_models[table_fqn]
             return model

--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -200,7 +200,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
         yield inspect(self.engine)
 
     def get_table_fqn(self, service_name, schema, table_name) -> str:
-        return f"{service_name}.{schema}.{table_name}"
+        return f"{service_name}.{schema}.{table_name}".lower()
 
     def next_record(self) -> Iterable[Entity]:
         inspectors = self.get_databases()
@@ -418,7 +418,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
                         columns=columns,
                         upstream=upstream_nodes,
                     )
-                    model_fqdn = f"{schema}.{model_name}"
+                    model_fqdn = f"{schema}.{model_name}".lower()
                 except Exception as err:
                     logger.debug(traceback.print_exc())
                     logger.error(err)


### PR DESCRIPTION
Add lower on model_fqn and get_table_fqn to increase matching between dbt and database references on Spark.

### Describe your changes :
Experienced that we did not get matching between dbt manifest/catalog and table metadata from database. Saw that we have defined all our dbt models with casing and that Databricks SQL (Spark) always returns all table and view casings as lower. Added lower() to increase matching between dbt and database schemas in case insensitive database table/view names. 

#
### Type of change :
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
